### PR TITLE
Add support for Test262 `id` tag

### DIFF
--- a/src/test/java/com/github/anba/es6draft/test262/Test262Info.java
+++ b/src/test/java/com/github/anba/es6draft/test262/Test262Info.java
@@ -323,6 +323,7 @@ final class Test262Info extends TestInfo {
         private String negative;
         private String es5id;
         private String es6id;
+        private String id;
         private String bestPractice;
         private String author;
 
@@ -388,6 +389,14 @@ final class Test262Info extends TestInfo {
 
         public void setEs6id(String es6id) {
             this.es6id = es6id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
         }
 
         public String getBestPractice() {


### PR DESCRIPTION
The maintainers of Test262 recently decided to encode specification
references with a version-independent `id` tag. Just like the `es5id`
and `es6id` tags before it, this tag has no effect on test execution.

Update the test parsing logic to tolerate th new `id` tag.