### PR TITLE
PARTIAL: Support testing ResolutionException

### DIFF
--- a/src/test/java/com/github/anba/es6draft/util/rules/ExceptionHandlers.java
+++ b/src/test/java/com/github/anba/es6draft/util/rules/ExceptionHandlers.java
@@ -21,6 +21,7 @@ import com.github.anba.es6draft.parser.ParserException;
 import com.github.anba.es6draft.repl.global.StopExecutionException;
 import com.github.anba.es6draft.runtime.ExecutionContext;
 import com.github.anba.es6draft.runtime.internal.ScriptException;
+import com.github.anba.es6draft.runtime.modules.ResolutionException;
 import com.github.anba.es6draft.util.TestAssertions;
 
 /**
@@ -42,12 +43,12 @@ public final class ExceptionHandlers {
     }
 
     /**
-     * {@link ExceptionHandler} for {@link ParserException}, {@link CompilationException} and {@link StackOverflowError}
-     * errors.
+     * {@link ExceptionHandler} for {@link ParserException}, {@link CompilationException}, {@link StackOverflowError}
+     * and {@link ResolutionException} errors.
      */
     public static final class StandardErrorHandler extends ExceptionHandler {
         private static final Matcher<Object> defaultMatcher = anyInstanceOf(ParserException.class,
-                CompilationException.class, StackOverflowError.class);
+                CompilationException.class, StackOverflowError.class, ResolutionException.class);
 
         public StandardErrorHandler() {
             this(defaultMatcher());
@@ -110,11 +111,12 @@ public final class ExceptionHandlers {
 
     /**
      * {@link ExceptionHandler} for {@link ParserException}, {@link CompilationException}, {@link StackOverflowError}
-     * and {@link ScriptException} errors.
+     * {@link ScriptException}, and {@link ResolutionException} errors.
      */
     public static final class IgnoreExceptionHandler extends ExceptionHandler {
         private static final Matcher<Object> defaultMatcher = anyInstanceOf(ParserException.class,
-                CompilationException.class, StackOverflowError.class, ScriptException.class);
+                CompilationException.class, StackOverflowError.class, ScriptException.class,
+                ResolutionException.class);
 
         public IgnoreExceptionHandler() {
             this(defaultMatcher());


### PR DESCRIPTION
*This patch is incomplete!*

The goal of this patch is to allow Test262 tests to express `negative:
SyntaxError` for module loading errors such as ambiguous import
bindings.

With this patch applied, the test runner fails with messages like this:

>     Expected: (((an instance of com.github.anba.es6draft.parser.ParserException or an instance of com.github.anba.es6draft.compiler.CompilationException or an instance of java.lang.StackOverflowError or an instance of com.github.anba.es6draft.runtime.modules.ResolutionException) or an instance of com.github.anba.es6draft.runtime.internal.ScriptException) and exception with error-message string matching 'SyntaxError')
>         but: exception with error-message string matching 'SyntaxError' error-message was "ambiguous export \"x\""
>     Stacktrace was: com.github.anba.es6draft.runtime.modules.ResolutionException: ambiguous export "x"
>     [...]

@anba Do you have any advice for how to proceed?