### PR TITLE
Update RegExpBuiltInExec to latest spec

### DIFF
--- a/src/main/java/com/github/anba/es6draft/runtime/objects/text/RegExpPrototype.java
+++ b/src/main/java/com/github/anba/es6draft/runtime/objects/text/RegExpPrototype.java
@@ -853,10 +853,9 @@ public final class RegExpPrototype extends OrdinaryObject implements Initializab
         /* steps 2-3 (not applicable) */
         /* steps 4-5 */
         int lastIndex = (int) Math.min(ToLength(cx, Get(cx, r, "lastIndex")), Integer.MAX_VALUE);
-        /* steps 6-7 */
-        boolean global = ToBoolean(Get(cx, r, "global"));
-        /* steps 8-9 */
-        boolean sticky = ToBoolean(Get(cx, r, "sticky"));
+        /* ES2016 steps 5-7 */
+        boolean global = r.isSet(RegExpObject.Flags.Global);
+        boolean sticky = r.isSet(RegExpObject.Flags.Sticky);
         /* steps 10-15 */
         MatchState m = matchOrNull(r, s, lastIndex, global, sticky);
         /* step 15.a, 15.c */


### PR DESCRIPTION
The ES2016 draft modifies the semantics of RegExpBuiltinExec to infer
"global" and "sticky" using the regular expression object's
[[OriginalFlags]] internal slot [1]. Update the algorithm accordingly.

This change removes two observable operations. An existing regression
test relied on one of these operations (accessing the `global` property)
during the evaluation of `RegExp.prototype[@@replace]`. Update the
regression test to use a different mechanism to assert the same
semantics.

[1] https://github.com/tc39/ecma262/pull/494