### PR TITLE
Build reports are not always needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <test.jvmArgs />
     <test.jacocoArgs />
     <test.excludes>**/chakra/*, **/mozilla/*, **/test262/*, **/v8/*, **/webkit/*</test.excludes>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencies>
@@ -209,6 +210,7 @@
                 <id>surefire-test</id>
                 <configuration>
                   <testFailureIgnore>true</testFailureIgnore>
+                  <disableXmlReport>${closeTestReports}</disableXmlReport>
                   <includes>
                     <include>**/chakra/*.java</include>
                     <include>**/mozilla/*.java</include>


### PR DESCRIPTION
That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.